### PR TITLE
Enable kernels_repo submodule init using HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kernels_repo"]
 	path = kernels_repo
-	url = git@github.com:threeearcat/kernels_repo.git
+	url = https://github.com/threeearcat/kernels_repo.git


### PR DESCRIPTION
Git was unable to find the public keys for kernels_repo submodule init so replacing with public HTTPS URL.